### PR TITLE
Fix multiline command end marker for OpenVox GSM Gateway

### DIFF
--- a/asterisk/manager.py
+++ b/asterisk/manager.py
@@ -331,7 +331,7 @@ class Manager(object):
                             line.split(':', 1)[1].strip() == 'Follows':
                         wait_for_marker = True
                     # same when seeing end of multiline response
-                    if multiline and line.startswith('--END COMMAND--'):
+                    if multiline and (line.startswith('--END COMMAND--') or line.strip().endswith('--END COMMAND--')):
                         wait_for_marker = False
                         multiline = False
                     # same when seeing end of status response


### PR DESCRIPTION
OpenVox GSM Gateway for command:
```
Action: Command
Command: gsm show span 1
```
send answer:
```
Response: Follows
Privilege: Command
D-channel: 2
Status: Power on, Provisioned, Up, Active, Standard
Type: CPE
Manufacturer: Revision: MTK 0828
Model Name: Quectel_M35
... skipped ...
Last event: D-Channel Up
State: READY
Last send AT: ATH\r\n--END COMMAND--
```