### PR TITLE
Support utf8 for commands.

### DIFF
--- a/asterisk/manager.py
+++ b/asterisk/manager.py
@@ -263,7 +263,7 @@ class Manager(object):
 
         # lock the socket and send our command
         try:
-            self._sock.write(command.encode('ascii'))
+            self._sock.write(command.encode('utf8'))
             self._sock.flush()
         except socket.error as e:
             raise ManagerSocketException(e.errno, e.strerror)
@@ -291,7 +291,7 @@ class Manager(object):
             try:
                 lines = []
                 for line in self._sock:
-                    line = line.decode('ascii')
+                    line = line.decode('utf8')
                     # check to see if this is the greeting line
                     if not self.title and '/' in line and not ':' in line:
                         # store the title of the manager we are connecting to:


### PR DESCRIPTION
I received error when I tried to send command with russian characters:
```
>>> manager.command('gsm send sync sms 6 7xxxxxxxxx "Тест русских букв" 10')
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/dextor/Projects/github/pyst2/asterisk/manager.py", line 604, in command
    response = self.send_action(cdict)
  File "/Users/dextor/Projects/github/pyst2/asterisk/manager.py", line 266, in send_action
    self._sock.write(command.encode('ascii'))
UnicodeEncodeError: 'ascii' codec can't encode characters in position 73-76: ordinal not in range(128)
```