### PR TITLE
correct line indentation, previously reulting in syntax error

### DIFF
--- a/asterisk/agi.py
+++ b/asterisk/agi.py
@@ -113,7 +113,7 @@ class AGI:
         sys.stderr.write('\n')
 
     def _quote(self, string):
-     """ provides double quotes to string, converts int/bool to string """
+        """ provides double quotes to string, converts int/bool to string """
         if isinstance(string, int):
           string = str(string)
         if isinstance(string, float):


### PR DESCRIPTION
With python3 I had a problem importing asterisk.agi.


root@ccreator ~ # python3
Python 3.4.2 (default, Oct  8 2014, 10:45:20) 
[GCC 4.9.1] on linux
>>> import asterisk.agi
Traceback (most recent call last):
File "<stdin>", line 1, in <module>
File "/usr/local/lib/python3.4/dist-packages/pyst2-0.4.7-py3.4.egg/asterisk/agi.py", line 117
    if isinstance(string, int):
    ^
IndentationError: unexpected indent
