### PR TITLE
Added ignore in decode of received lines

### DIFF
--- a/asterisk/manager.py
+++ b/asterisk/manager.py
@@ -291,7 +291,7 @@ class Manager(object):
             try:
                 lines = []
                 for line in self._sock:
-                    line = line.decode('utf8')
+                    line = line.decode('utf8','ignore')
                     # check to see if this is the greeting line
                     if not self.title and '/' in line and not ':' in line:
                         # store the title of the manager we are connecting to:


### PR DESCRIPTION
If this fails kill the message_thread.

In our environment that we have special characters (spanish ones) this occurs very often and cause the message_thread to quit with a unhandled exception.

Ignoring special characters fix the problem.