### PR TITLE
Fixed send_command to work with python3.

### DIFF
--- a/asterisk/agi.py
+++ b/asterisk/agi.py
@@ -163,10 +163,7 @@ class AGI:
         if command[-1] != '\n':
             command += '\n'
         self.stderr.write('    COMMAND: %s' % command)
-        if PY3:
-            self.stdout.write(command.encode('utf8'))
-        else:
-            self.stdout.write(command)
+        self.stdout.write(command)
         self.stdout.flush()
 
     def get_result(self, stdin=sys.stdin):


### PR DESCRIPTION
This is a fix for #40, `sys.stdout.write` never accepted bytes in any version of Python 3.